### PR TITLE
EXPERIEMNTAL: pd_cp_manager: add safety margin to thermal FCC bypass check

### DIFF
--- a/drivers/power/supply/xiaomi/pd_cp_manager.c
+++ b/drivers/power/supply/xiaomi/pd_cp_manager.c
@@ -683,10 +683,12 @@ static void pdm_bypass_check(struct usbpd_pm *pdpm)
 				else
 					pdpm->switch_mode = false;
 			} else {
-				if ((pdpm->thermal_limit_fcc > 0) &&(pdpm->thermal_limit_fcc <= pdpm->bypass_entry_fcc))
-					pdpm->switch_mode = true;
+				// Only enter bypass if thermal FCC is well below entry limit
+				if ((pdpm->thermal_limit_fcc > 0) &&
+						(pdpm->thermal_limit_fcc <= pdpm->bypass_entry_fcc - 1000000)) // 1A margin
+						pdpm->switch_mode = true;
 				else
-					pdpm->switch_mode = false;
+						pdpm->switch_mode = false;
 			}
 		} else {
 			pdpm->switch_mode = false;


### PR DESCRIPTION
Added a 1A safety margin when evaluating thermal_limit_fcc for bypass entry. This ensures bypass mode is only entered when the thermal limit is significantly below the entry threshold, reducing the risk of oscillation or overheating.

No jiffies/timing logic is used for simplicity and compatibility. Thermal FCC checks are still enforced.